### PR TITLE
add trailer handling

### DIFF
--- a/pkg/http/compress/compress.go
+++ b/pkg/http/compress/compress.go
@@ -82,7 +82,7 @@ func (dr *dataRecorder) finish() {
 	}
 
 	if !found {
-		ctype := http.DetectContentType(dr.body.Bytes()[:512])
+		ctype := http.DetectContentType(dr.body.Bytes())
 		dr.headers.Set("Content-Type", ctype)
 	}
 }
@@ -155,21 +155,13 @@ func Compress(logger *log.Logger, next http.Handler) http.Handler {
 		}
 
 		w.Header().Set("Content-Length", strconv.Itoa(len(body)))
-		w.Write(body)
 
-		// trailer keys are stored in the Headers with the key "Trailer"
-		var trailers []string
-		for k, v := range recorder.headers {
-			if k == "Trailer" {
-				trailers = v
-			}
-		}
-
-		// for each trailer key, send the provided values
-		for _, k := range trailers {
-			if v, found := recorder.headers[k]; found {
+		for _, k := range recorder.headers["Trailer"] {
+			if v, found := recorder.shadow[k]; found {
 				w.Header()[k] = v
 			}
 		}
+
+		w.Write(body)
 	})
 }

--- a/pkg/http/compress/compress_test.go
+++ b/pkg/http/compress/compress_test.go
@@ -126,3 +126,30 @@ func TestCompress(t *testing.T) {
 		})
 	}
 }
+
+func TestCompressTrailers(t *testing.T) {
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	h := Compress(log.Default(), http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Hdr1", "HdrVal1")
+		w.Header().Set("Hdr2", "HdrVal2")
+		w.Header().Set("Trailer", "AtEnd1, AtEnd2")
+
+		w.WriteHeader(http.StatusOK)
+
+		w.Header().Set("AtEnd1", "EndVal1")
+		w.Header().Set("AtEnd2", "EndVal2")
+	}))
+
+	h.ServeHTTP(w, r)
+
+	result := w.Result()
+
+	for k, v := range result.Header {
+		t.Log(k, v)
+	}
+	for k, v := range result.Trailer {
+		t.Log(k, v)
+	}
+}


### PR DESCRIPTION
The Go standard library lets the developer indicate which headers will
be trailers. We avoid sending this key as a header, then use it to
determine which header values to send as trailers.